### PR TITLE
Source code injection and linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,640 @@
+AllCops:
+  Exclude:
+    - db/schema.rb
+
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+
+Style/Alias:
+  Description: 'Use alias_method instead of alias.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
+  Enabled: false
+
+Style/ArrayJoin:
+  Description: 'Use Array#join instead of Array#*.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#array-join'
+  Enabled: false
+
+Style/AsciiComments:
+  Description: 'Use only ascii symbols in comments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
+  Enabled: false
+
+Naming/AsciiIdentifiers:
+  Description: 'Use only ascii symbols in identifiers.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
+  Enabled: false
+
+Style/Attr:
+  Description: 'Checks for uses of Module#attr.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
+  Enabled: false
+
+Metrics/BlockNesting:
+  Description: 'Avoid excessive block nesting'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
+  Enabled: false
+
+Style/CaseEquality:
+  Description: 'Avoid explicit use of the case equality operator(===).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
+  Enabled: false
+
+Style/CharacterLiteral:
+  Description: 'Checks for uses of character literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-character-literals'
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Description: 'Checks style of children classes and modules.'
+  Enabled: true
+  EnforcedStyle: nested
+
+Metrics/ClassLength:
+  Description: 'Avoid classes longer than 100 lines of code.'
+  Enabled: false
+
+Metrics/ModuleLength:
+  Description: 'Avoid modules longer than 100 lines of code.'
+  Enabled: false
+
+Style/ClassVars:
+  Description: 'Avoid the use of class variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
+  Enabled: false
+
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    find: detect
+    inject: reduce
+    collect: map
+    find_all: select
+
+Style/ColonMethodCall:
+  Description: 'Do not use :: for method call.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
+  Enabled: false
+
+Style/CommentAnnotation:
+  Description: >-
+                 Checks formatting of special comments
+                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
+  Enabled: false
+
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Enabled: false
+
+Metrics/BlockLength:
+  CountComments: true  # count full line comments?
+  Max: 25
+  ExcludedMethods: []
+  Exclude:
+    - "spec/**/*"
+
+Metrics/CyclomaticComplexity:
+  Description: >-
+                 A complexity metric that is strongly correlated to the number
+                 of test cases needed to validate a method.
+  Enabled: false
+
+Rails/Delegate:
+  Description: 'Prefer delegate method for delegations.'
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
+  StyleGuide: '#hash-key'
+  Enabled: false
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+
+Style/DoubleNegation:
+  Description: 'Checks for uses of double negation (!!).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
+  Enabled: false
+
+Style/EachWithObject:
+  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
+  Enabled: false
+
+Style/EmptyLiteral:
+  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'
+  Enabled: false
+
+# Checks whether the source file has a utf-8 encoding comment or not
+# AutoCorrectEncodingComment must match the regex
+# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+Style/Encoding:
+  Enabled: false
+
+Style/EvenOdd:
+  Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
+  Enabled: false
+
+Naming/FileName:
+  Description: 'Use snake_case for source file names.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Description: >-
+    Add the frozen_string_literal comment to the top of files
+    to help transition from Ruby 2.3.0 to Ruby 3.0.
+  Enabled: false
+
+Style/FlipFlop:
+  Description: 'Checks for flip flops'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
+  Enabled: false
+
+Style/FormatString:
+  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
+  Enabled: false
+
+Style/GlobalVars:
+  Description: 'Do not introduce global variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#instance-vars'
+  Reference: 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
+  Enabled: false
+
+Style/GuardClause:
+  Description: 'Check for conditionals that can be replaced with guard clauses'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Description: >-
+                 Favor modifier if/unless usage when you have a
+                 single-line body.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier'
+  Enabled: false
+
+Style/IfWithSemicolon:
+  Description: 'Do not use if x; .... Use the ternary operator instead.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
+  Enabled: false
+
+Style/InlineComment:
+  Description: 'Avoid inline comments.'
+  Enabled: false
+
+Style/Lambda:
+  Description: 'Use the new lambda literal syntax for single-line blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
+  Enabled: false
+
+Style/LambdaCall:
+  Description: 'Use lambda.call(...) instead of lambda.(...).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Description: >-
+                 Use \ instead of + or << to concatenate two string literals at
+                 line end.
+  Enabled: false
+
+Metrics/LineLength:
+  Description: 'Limit lines to 80 characters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  Max: 80
+
+Metrics/MethodLength:
+  Description: 'Avoid methods longer than 10 lines of code.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
+  Enabled: false
+
+Style/ModuleFunction:
+  Description: 'Checks for usage of `extend self` in modules.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Description: 'Avoid multi-line chains of blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: false
+
+Style/NegatedIf:
+  Description: >-
+                 Favor unless over if for negative conditions
+                 (or control flow or).
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#unless-for-negatives'
+  Enabled: false
+
+Style/NegatedWhile:
+  Description: 'Favor until over while for negative conditions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#until-for-negatives'
+  Enabled: false
+
+Style/Next:
+  Description: 'Use `next` to skip iteration instead of a condition at the end.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
+  Enabled: false
+
+Style/NilComparison:
+  Description: 'Prefer x.nil? to x == nil.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
+  Enabled: false
+
+Style/Not:
+  Description: 'Use ! instead of not.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bang-not-not'
+  Enabled: false
+
+Style/NumericLiterals:
+  Description: >-
+                 Add underscores to large numeric literals to improve their
+                 readability.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: false
+
+Style/OneLineConditional:
+  Description: >-
+                 Favor the ternary operator(?:) over
+                 if/then/else/end constructs.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Description: 'When defining binary operators, name the argument other.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
+  Enabled: false
+
+Metrics/ParameterLists:
+  Description: 'Avoid parameter lists longer than three or four parameters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Description: 'Use `%`-literal delimiters consistently'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
+  Enabled: false
+
+Style/PerlBackrefs:
+  Description: 'Avoid Perl-style regex back references.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
+  Enabled: false
+
+Naming/PredicateName:
+  Description: 'Check the names of predicate methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
+  NamePrefixBlacklist:
+    - is_
+  Exclude:
+    - spec/**/*
+
+Style/Proc:
+  Description: 'Use proc instead of Proc.new.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc'
+  Enabled: false
+
+Style/RaiseArgs:
+  Description: 'Checks the arguments passed to raise/fail.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#exception-class-messages'
+  Enabled: false
+
+Style/RegexpLiteral:
+  Description: 'Use / or %r around regular expressions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
+  Enabled: false
+
+Style/SelfAssignment:
+  Description: >-
+                 Checks for places where self-assignment shorthand should have
+                 been used.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#self-assignment'
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Description: 'Enforces the names of some block params.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#reduce-blocks'
+  Enabled: false
+
+Style/SingleLineMethods:
+  Description: 'Avoid single-line methods.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
+  Enabled: false
+
+Style/SignalException:
+  Description: 'Checks for proper usage of fail and raise.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Description: 'Avoid Perl-style global variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
+  Enabled: false
+
+Style/StringLiterals:
+  Description: 'Checks if uses of quotes match the configured preference.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
+  EnforcedStyle: double_quotes
+  Enabled: true
+
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrivialAccessors:
+  Description: 'Prefer attr_* methods to trivial readers/writers.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
+  Enabled: false
+
+Style/VariableInterpolation:
+  Description: >-
+                 Don't interpolate global, instance and class variables
+                 directly in strings.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#curlies-interpolate'
+  Enabled: false
+
+Style/WhenThen:
+  Description: 'Use when x then ... for one-line cases.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#one-line-cases'
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Description: >-
+                 Favor modifier while/until usage when you have a
+                 single-line body.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier'
+  Enabled: false
+
+Style/WordArray:
+  Description: 'Use %w or %W for arrays of words.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
+  Enabled: false
+
+# Layout
+
+Layout/AlignParameters:
+  Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: false
+
+Layout/DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
+  EnforcedStyle: trailing
+
+Layout/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
+  Enabled: true
+
+Layout/MultilineOperationIndentation:
+  Description: >-
+                 Checks indentation of binary operations that span more than
+                 one line.
+  Enabled: true
+  EnforcedStyle: indented
+
+Layout/MultilineMethodCallIndentation:
+  Description: >-
+                 Checks indentation of method calls with the dot operator
+                 that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+
+Layout/InitialIndentation:
+  Description: >-
+    Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: false
+
+# Lint
+
+Lint/AmbiguousOperator:
+  Description: >-
+                 Checks for ambiguous operators in the first argument of a
+                 method invocation without parentheses.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
+  Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+  Description: >-
+                 Checks for ambiguous regexp literals in the first argument of
+                 a method invocation without parenthesis.
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Description: "Don't use assignment in conditions."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
+  Enabled: false
+
+Lint/CircularArgumentReference:
+  Description: "Don't refer to the keyword argument in the default value."
+  Enabled: false
+
+Lint/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
+  Enabled: false
+
+Lint/DeprecatedClassMethods:
+  Description: 'Check for deprecated class method calls.'
+  Enabled: false
+
+Lint/DuplicatedKey:
+  Description: 'Check for duplicate keys in hash literals.'
+  Enabled: false
+
+Lint/EachWithObjectArgument:
+  Description: 'Check for immutable argument given to each_with_object.'
+  Enabled: false
+
+Lint/ElseLayout:
+  Description: 'Check for odd code arrangement in an else block.'
+  Enabled: false
+
+Lint/FormatParameterMismatch:
+  Description: 'The number of parameters to format/sprint must match the fields.'
+  Enabled: false
+
+Lint/HandleExceptions:
+  Description: "Don't suppress exception."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
+  Enabled: false
+
+Lint/LiteralAsCondition:
+  Description: 'Checks for literals used in conditions.'
+  Enabled: false
+
+Lint/LiteralInInterpolation:
+  Description: 'Checks for literals used in interpolation.'
+  Enabled: false
+
+Lint/Loop:
+  Description: >-
+                 Use Kernel#loop with break rather than begin/end/until or
+                 begin/end/while for post-loop tests.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Description: 'Do not use nested method definitions.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
+  Enabled: false
+
+Lint/NonLocalExitFromIterator:
+  Description: 'Do not use return in iterator to cause non-local exit.'
+  Enabled: false
+
+Lint/ParenthesesAsGroupedExpression:
+  Description: >-
+                 Checks for method calls with a space before the opening
+                 parenthesis.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: false
+
+Lint/RequireParentheses:
+  Description: >-
+                 Use parentheses in the method call to avoid confusion
+                 about precedence.
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Description: 'Do not use prefix `_` for a variable that is used.'
+  Enabled: false
+
+Lint/UnneededDisable:
+  Description: >-
+                 Checks for rubocop:disable comments that can be removed.
+                 Note: this cop is not disabled when disabling all cops.
+                 It must be explicitly disabled.
+  Enabled: false
+
+Lint/Void:
+  Description: 'Possible use of operator/literal/variable in void context.'
+  Enabled: false
+
+# Performance
+
+Performance/CaseWhenSplat:
+  Description: >-
+                  Place `when` conditions that use splat at the end
+                  of the list of `when` branches.
+  Enabled: false
+
+Performance/Count:
+  Description: >-
+                  Use `count` instead of `select...size`, `reject...size`,
+                  `select...count`, `reject...count`, `select...length`,
+                  and `reject...length`.
+  Enabled: false
+
+Performance/Detect:
+  Description: >-
+                  Use `detect` instead of `select.first`, `find_all.first`,
+                  `select.last`, and `find_all.last`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
+  Enabled: false
+
+Performance/FlatMap:
+  Description: >-
+                  Use `Enumerable#flat_map`
+                  instead of `Enumerable#map...Array#flatten(1)`
+                  or `Enumberable#collect..Array#flatten(1)`
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
+  Enabled: false
+
+Performance/ReverseEach:
+  Description: 'Use `reverse_each` instead of `reverse.each`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
+  Enabled: false
+
+Performance/Sample:
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: false
+
+Performance/Size:
+  Description: >-
+                  Use `size` instead of `count` for counting
+                  the number of elements in `Array` and `Hash`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
+  Enabled: false
+
+Performance/StringReplacement:
+  Description: >-
+                  Use `tr` instead of `gsub` when you are replacing the same
+                  number of characters. Use `delete` instead of `gsub` when
+                  you are deleting characters.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
+  Enabled: false
+
+# Rails
+
+Rails/ActionFilter:
+  Description: 'Enforces consistent use of action filter methods.'
+  Enabled: false
+
+Rails/Date:
+  Description: >-
+                  Checks the correct usage of date aware methods,
+                  such as Date.today, Date.current etc.
+  Enabled: false
+
+Rails/FindBy:
+  Description: 'Prefer find_by over where.first.'
+  Enabled: false
+
+Rails/FindEach:
+  Description: 'Prefer all.find_each over all.find.'
+  Enabled: false
+
+Rails/HasAndBelongsToMany:
+  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
+  Enabled: false
+
+Rails/Output:
+  Description: 'Checks for calls to puts, print, etc.'
+  Enabled: false
+
+Rails/ReadWriteAttribute:
+  Description: >-
+                 Checks for read_attribute(:attr) and
+                 write_attribute(:attr, val).
+  Enabled: false
+
+Rails/ScopeArgs:
+  Description: 'Checks the arguments of ActiveRecord scopes.'
+  Enabled: false
+
+Rails/TimeZone:
+  Description: 'Checks the correct usage of time zone aware methods.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
+  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
+  Enabled: false
+
+Rails/Validation:
+  Description: 'Use validates :attribute, hash of validations.'
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org" do
   group :development do
     gem "pandoc-ruby"
+    gem "rubocop"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     pandoc-ruby (2.0.2)
+    ast (2.3.0)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
+    powerpack (0.1.1)
+    rainbow (3.0.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   pandoc-ruby!
+  rubocop!
 
 BUNDLED WITH
    1.16.0.pre.3

--- a/book/1_introduction/iii_tooling.md
+++ b/book/1_introduction/iii_tooling.md
@@ -8,15 +8,11 @@ What is ncurses you ask? ncurses stands for *new curses*, it's a freeware reimpl
 
 This screen was created using ncurses. So why do *we* need ncurses? After all, we're just writing a simple game. Using Ruby let's try to do something simple like clearing the screen. If you're on macOS you might have written something like:
 
-```ruby
-system("clear")
-```
+!{code/1_iii_tooling_1.rb}
 
 Everything works great until you try to run this code on Windows. It will fail on Windows because there is no `clear.exe`. On Windows we need to run:
 
-```ruby
-system("CLS")
-```
+!{code/1_iii_tooling_2.rb}
 
 Now we'd need to run code to detect the OS. We'd need to import `rbconfig` and write some code to detect the OS and choose the correct code to run. We can avoid this by using ncurses, which will do all the heavy lifting for us. In order to use it, you'll need to make sure you have ncurses installed on your system. For Windows, you'll most likely want to use a version of Ruby that comes with ncurses in its standard library. In my case, I've gotten it running by using ruby 1.9.3p484. If you're using a Unix-based system you can most likely run `man ncurses` and if a man page comes up you should be set. If nothing comes up you'll want to install `ncurses-dev` via whatever package manager your system utilizes.
 

--- a/book/2_generating_a_character/1_the_title_screen.md
+++ b/book/2_generating_a_character/1_the_title_screen.md
@@ -12,90 +12,23 @@ Now that we have the curses gem installed, we can start working on the title scr
 
 Let's start our game by writing the simplest curses example we can come up with. The program will initialize curses, read a single character, and then quit. To do this, create a file named `main.rb` and add the following:
 
-```ruby
-require "curses" # require the curses gem
-include Curses   # mixin curses
-
-# The next three methods are provided by including the Curses module.
-
-init_screen      # starts curses visual mode
-getch            # reads a single character from stdin
-close_screen     # closes the ncurses screen
-```
+!{code/2_1_title_screen_1.rb}
 
 If you run this program, you will see the terminal go black and upon pressing a character it will return back to normal.
 
 Now that we've got a simple curses example running, let's work on our title screen. We're going to break our code up into three files. The first file we'll create is named `ui.rb`. This will hold all of our interface routines.  We're breaking the UI into its own class for a few reasons. First, in game development, it's easy to produce code that is difficult to understand. We want to avoid this by trying to employ the single-responsibility pattern as much as possible. Tangentally, if we decide to replace our UI implementation with a different one, the isolation here makes doing that far easier. The implementation for our `UI` class will look like this:
 
-```ruby
-class UI
-  include Curses
-
-  def initialize
-    noecho # do not print characters the user types
-    init_screen
-  end
-
-  def close
-    close_screen
-  end
-
-  def message(y, x, string)
-    setpos(y, x) # place the cursor at our position
-    addstr(string) # prints a string at cursor position
-  end
-
-  def choice_prompt(y, x, string, choices)
-    message(y, x, string + " ")
-
-    loop do
-      choice = getch
-      return choice if choices.include?(choice)
-    end
-  end
-end
-```
+!{code/2_1_title_screen_2.rb}
 
 You may be wondering why we're passing values in (y, x) order instead of (x, y). We're passing the values as (y, x) because that's the order ncurses will expect to see them in. ncurses wants the coordinates in (y, x) order because of how it renders the screen. Essentially, ncurses will start in the top left of the screen, y = 0, and then write out the entire line before moving on to the next line, y = 1. By storing the y coordinate first it can handle this process more optimally.
 
 Now let's create the file `game.rb` which will hold our `Game` class. The responsibility of the `Game` class is to execute the main run loop as well as manage setup and global state. The implementation for the `Game` class will look like this:
 
-```ruby
-class Game
-  def initialize
-    @ui = UI.new
-    at_exit { ui.close } # runs at program exit
-  end
-
-  def run
-    title_screen
-  end
-
-  private
-
-  attr_reader :ui
-
-  def title_screen
-    ui.message(0, 0, "Rhack, a NetHack clone")
-    ui.message(1, 7, "by a daring developer")
-    ui.choice_prompt(3, 0, "Shall I pick a character's race, role, gender and " + 
-      "alignment for you? [ynq]", "ynq")
-  end
-end
-```
+!{code/2_1_title_screen_3.rb}
 
 Finally, change the `main.rb` file to use our new classes:
 
-```ruby
-$LOAD_PATH.unshift "." # makes requiring files easier
-
-require "pp"
-require "curses"
-require "ui"
-require "game"
-
-Game.new.run
-```
+!{code/2_1_title_screen_4.rb}
 
 If you run the program now, it will look very much like the initial NetHack screen.
 
@@ -103,74 +36,16 @@ If you run the program now, it will look very much like the initial NetHack scre
 
 Moving forward, we're going to want to show more than a title screen. Let's start by refactoring our current code into something more adaptable. Refactor `game.rb` to the following:
 
-```ruby
-class Game
-  def initialize
-    @ui = UI.new
-    @options = { quit: false, randall: false } # variable for options
-    at_exit { ui.close; pp options } # See selected options at exit
-  end
-
-  def run
-    title_screen
-  end
-
-  private
-
-  attr_reader :ui, :options # Add attr_reader for options
-
-  def title_screen
-    TitleScreen.new(ui, options).render
-    quit?
-  end
-
-  def quit?
-    exit if options[:quit]
-  end
-end
-```
+!{code/2_1_title_screen_5.rb}
 
 Now we'll create a `title_screen.rb` file with the following:
 
-```ruby
-class TitleScreen
-  def initialize(ui, options)
-    @ui = ui
-    @options = options
-  end
-
-  def render
-    ui.message(0, 0, "Rhack, a NetHack clone")
-    ui.message(1, 7, "by a daring developer")
-    handle_choice prompt
-  end
-
-  private
-
-  attr_reader :ui, :options
-
-  def prompt
-    ui.choice_prompt(3, 0, "Shall I pick a character's race, role, gender and " + 
-      "alignment for you? [ynq]", "ynq")
-  end
-
-  def handle_choice(choice)
-    case choice
-    when "q" then options[:quit] = true
-    when "y" then options[:randall] = true
-    end
-  end
-end
-```
+!{code/2_1_title_screen_6.rb}
 
 You can see here how we'll be making use of the `options` variable created in `game.rb`. It will store the selections the user makes during setup. We need to do this in order to communicate between the different selection screens about what choices the player has made. If the user selects "q" we'll store that we need to quit, if they choose "y" then we'll randomly assign the rest of the traits. In order to keep our application working you'll also need to add:
 
-```ruby
-require "title_screen"
-```
+!{code/2_1_title_screen_7.rb}
 
 to `main.rb`. Now when running the program and choose an option you'll see set in the output that is printed. For instance, if I select yes, then I'll see the following:
 
-```ruby
 {:quit=>false, :randall=>true}
-```

--- a/book/2_generating_a_character/2_messages.md
+++ b/book/2_generating_a_character/2_messages.md
@@ -2,87 +2,32 @@
 
 There are going to be a lot of in-game messages and to make things more fluid we should extract them into a yaml file. This makes them far easier to change (or to internationalize) later. Let's start by creating a `data` directory. This directory will hold some yaml files that will contain in game text and other data. In that directory, let's create a file for holding our in-game messages. Name the file `messages.yaml` and add the following to it:
 
-```yaml
----
-title:
-  name: Rhack, a NetHack clone
-  by: by a daring developer
-  pick_random: "Shall I pick a character's race, role, gender and alignment for you? [ynq]"
-```
+!{code/2_2_messages_1.yaml}
 
 Next, we'll want to update our `TitleScreen` class to make use of these messages. In order to do that, we'll first need some way to load the yaml file. In this situation, it's a good idea to isolate an external dependency like YAML in order to make it easier to replace or modify in the future. We took this exact approach with Curses by extracting the UI into its own class. Let's extract a `DataLoader` class that knows how to load our data for us. Create a `data_loader.rb` file with the following:
 
-```ruby
-class DataLoader
-  def self.load_file(file)
-    new.load_file(file)
-  end
-
-  def load_file(file)
-    symbolize_keys YAML.load_file("data/#{file}.yaml")
-  end
-
-  private
-
-  def symbolize_keys(object)
-    case object
-    when Hash
-      object.each_with_object({}) do |(key, value), hash|
-        hash[key.to_sym] = symbolize_keys(value)
-      end
-    when Array
-      object.map { |element| symbolize_keys(element) }
-    else
-      object
-    end
-  end
-end
-```
+!{code/2_2_messages_2.rb}
 
 The reason behind `symbolize_keys` is that YAML will parse all the keys as strings and I prefer symbols for this. Even though `ActiveSupport` has a similar method, we're going to leave it out because it won't work directly with arrays. Our implementation will symbolize the keys correctly for hashes or arrays even if they are nested.
 
 Now we'll create a global way to access these messages. Create a file called `messages.rb` with the following:
 
-```ruby
-module Messages
-  def self.messages
-    @messages ||= DataLoader.load_file("messages")
-  end
-
-  def self.[](key)
-    messages[key]
-  end
-end
-```
+!{code/2_2_messages_3.rb}
 
 It's evident here that our Messages module knows nothing about the YAML backend, instead it simply asks our DataLoader to load the messages. Now that we have a way to get our messages let's change our `title_screen.rb` to make use of it. In `initialize` add the following:
 
-```ruby
-@messages = Messages[:title]
-```
+!{code/2_2_messages_4.rb}
 
 Make sure to add `:messages` to the `attr_reader` line, like so:
 
-```ruby
-attr_reader :ui, :options, :messages
-```
+!{code/2_2_messages_5.rb}
 
 and then change `render` to the following:
 
-```ruby
-def render
-  ui.message(0, 0, messages[:name])
-  ui.message(1, 7, messages[:by])
-  handle_choice prompt
-end
-```
+!{code/2_2_messages_6.rb}
 
 And change `prompt` to:
 
-```ruby
-def prompt
-  ui.choice_prompt(3, 0, messages[:pick_random], "ynq")
-end
-```
+!{code/2_2_messages_7.rb}
 
 Now to finish up, add `require`s in `main.rb` for `yaml`, `data_loader`, and `messages`. When you run the program again it should still function like our previous implementation.

--- a/book/2_generating_a_character/3_role_call.md
+++ b/book/2_generating_a_character/3_role_call.md
@@ -8,263 +8,91 @@ We'll start by allowing the player to choose their role. In NetHack, these are t
 
 We will implement all of these. Looking at this list, "data" should immediately come to mind. We're going to create another data file to hold the information for our roles. To start with, we're going to give each role a `name` and a `hotkey`. Create `data/roles.yaml` with the following:
 
-```yaml
----
-- name: Archeologist
-  hotkey: a
-- name: Barbarian
-  hotkey: b
-- name: Caveman
-  hotkey: c
-- name: Healer
-  hotkey: h
-- name: Knight
-  hotkey: k
-- name: Monk
-  hotkey: m
-- name: Priest
-  hotkey: p
-- name: Rogue
-  hotkey: r
-- name: Ranger
-  hotkey: R
-- name: Samurai
-  hotkey: s
-- name: Tourist
-  hotkey: t
-- name: Valkyrie
-  hotkey: v
-- name: Wizard
-  hotkey: w
-```
+!{code/2_3_role_call_1.yaml}
 
 Now we're going to create a `Role` class that can load all of this data. Create a file named `role.rb` with the following:
 
-```ruby
-class Role
-  def self.for_options(_)
-    all
-  end
-
-  def self.all
-    DataLoader.load_file("roles").map do |data|
-      new(data)
-    end
-  end
-
-  attr_reader :name, :hotkey
-
-  def initialize(data)
-    data.each do |key, value|
-      instance_variable_set("@#{key}", value)
-    end
-  end
-
-  def to_s
-    name
-  end
-end
-```
+!{code/2_3_role_call_2.rb}
 
 We're using for_options here to unify the interface across all of our characteristics, since race and alignment will be dependent on role. We'll see shortly why this abstraction makes sense.
 
 Now we're going to write a generic `SelectionScreen` class. It's job will be to print two messages and display a list of options that can be selected by a hotkey. Create the file `selection_screen.rb` with:
 
-```ruby
-class SelectionScreen
-end
-```
+!{code/2_3_role_call_3.rb}
 
 Now let's add some methods one by one. First we'll add our `initialize` and some `attr_reader`s:
 
-```ruby
-def initialize(trait, ui, options)
-  @items = trait.for_options(options)
-
-  @ui = ui
-  @options = options
-
-  @key = trait.name.downcase.to_sym
-  @messages = Messages[key]
-end
-
-private
-
-attr_reader :items, :ui, :options, :key, :messages
-```
+!{code/2_3_role_call_4.rb}
 
 When we create a our selection screen we'll call it from `game.rb` with:
 
-```ruby
-SelectionScreen.new(Role, ui, options).render
-```
+!{code/2_3_role_call_5.rb}
 
 So in this case, `trait` will be the class `Role`. On the first line we fetch all the relevant roles by calling `for_options`. If you recall, `for_options` just reads the yaml file of roles and returns all of them. Next we assign the `ui` and `options` variables. Then, we determine a key that we'll use for a couple of things. If `Role` is our trait, then we want `:role` to be our key. Finally, we grab a hash of messages related to our key (:role in this case).
 
 Now we'll implement our only **public** method `render` (make sure this goes above the `private` line):
 
-```ruby
-def render
-  if random?
-    options[key] = random_item
-  else
-    render_screen
-  end
-end
-```
+!{code/2_3_role_call_6.rb}
 
 In this method we check to see if we need to randomly select an item. If we do we don't want to render the screen, so it simply sets the option and returns. Otherwise we'll render the screen. The implementation for `random?` and `random_item` look like this:
 
-```ruby
-def random?
-  options[:randall]
-end
-
-def random_item
-  items.sample
-end
-```
+!{code/2_3_role_call_7.rb}
 
 For now, `random?` simply checks if `randall` was set and `random_item` just chooses a random element form our items array. Now we can implement `render_screen` and `instructions`:
 
-```ruby
-def render_screen
-  ui.clear
-  ui.message(0, 0, messages[:choosing])
-  ui.message(0, right_offset, instructions)
-  render_choices
-  handle_choice prompt
-end
-
-# instructions has been pulled out into it's own method for a reason
-# you will see later
-
-def instructions
-  messages[:instructions]
-end
-```
+!{code/2_3_role_call_8.rb}
 
 Here we clear the screen, display the message on the left - "Choosing Role", display the message on the right - "Pick the role of your character", display the choices, and then prompt and handle the player's selection. For convenience, I've pulled out `right_offset` into a method since we'll use it a few times:
 
-```ruby
-def right_offset
-  @right_offset ||= (instructions.length + 2) * -1
-end
-```
+!{code/2_3_role_call_9.rb}
 
 This method returns a negative number representing how far left from the right side we should be when printing the right half of our screen.  We'll need to update our `UI` class to handle negative numbers, but let's finish our `SelectionScreen` class first.
 
 Now we'll write our method for rendering our choices
 
-```ruby
-def render_choices
-  items.each_with_index do |item, index|
-    ui.message(index + 2, right_offset, "#{item.hotkey} - #{item}")
-  end
-
-  ui.message(items.length + 2, right_offset, "* - Random")
-  ui.message(items.length + 3, right_offset, "q - Quit")
-end
-```
+!{code/2_3_role_call_10.rb}
 
 This method is relatively straight forward. We loop through each item and print out the hotkey and the name of the role (we're cheating here by not printing "a" or "an" in front of the name, but it's not really important).
 
 Now let's implement `handle_choice` and `item_for_hotkey`:
 
-```ruby
-def handle_choice(choice)
-  case choice
-  when "q" then options[:quit] = true
-  when "*" then options[key] = random_item
-  else options[key] = item_for_hotkey(choice)
-  end
-end
-
-def item_for_hotkey(hotkey)
-  items.find { |item| item.hotkey == hotkey }
-end
-```
+!{code/2_3_role_call_11.rb}
 
 Here we have 3 choices. If the user presses "q" then we want to quit. If they press "*" then we want to randomly choose an item. If they press any other valid option we want to assign the corresponding role.
 
 Finally let's implement `prompt` and `hotkeys`:
 
-```ruby
-def prompt
-  ui.choice_prompt(items.length + 4, right_offset, "(end)", hotkeys)
-end
-
-def hotkeys
-  items.map(&:hotkey).join + "*q"
-end
-```
+!{code/2_3_role_call_12.rb}
 
 The `hotkeys` represent our valid choices, but we need to make sure to add "*" and "q" as valid hotkeys.
 
 Now we're ready to initialize this screen in `game.rb`. Add the following constant:
 
-```ruby
-TRAITS = [Role]
-```
+!{code/2_3_role_call_13.rb}
 
 Then change the `run` method to look like this:
 
-```ruby
-def run
-  title_screen
-  setup_character
-end
-```
+!{code/2_3_role_call_14.rb}
 
 And then add `setup_character` and `get_traits` as a private methods:
 
-```ruby
-def setup_character
-  get_traits
-end
-
-def get_traits
-  TRAITS.each do |trait|
-    SelectionScreen.new(trait, ui, options).render
-    quit?
-  end
-end
-```
+!{code/2_3_role_call_15.rb}
 
 There are a few things left to do in order to get this working. First, in `main.rb` add:
 
-```ruby
-require "role"
-require "selection_screen"
-```
+!{code/2_3_role_call_16.rb}
 
 **Above** the `require "game"` line. Next, we'll need to modify our `UI` class to have a `clear` method. Curses provides this method, but it's private, so we'll need to add the following to `ui.rb`:
 
-```ruby
-def clear
-  super # call curses's clear method
-end
-```
+!{code/2_3_role_call_17.rb}
 
 While we have the `ui.rb` file open we should handle our `right_offset` issue we described before. Change the implementation of `message` to the following:
 
-```ruby
-def message(x, y, string)
-  x = x + cols if x < 0
-  y = y + lines if y < 0
-
-  setpos(y, x)
-  addstr(string)
-end
-```
+!{code/2_3_role_call_18.rb}
 
 Finally, we'll need to add some messages to our `data/messages.yaml` file:
 
-```yaml
-role:
-  choosing: Choosing Role
-  instructions: Pick a role for your character
-```
+!{code/2_3_role_call_19.yaml}
 
 If you run the program and choose "n" for the first choice then you should see:
 

--- a/code/1_iii_tooling_1.rb
+++ b/code/1_iii_tooling_1.rb
@@ -1,0 +1,1 @@
+system("clear")

--- a/code/1_iii_tooling_2.rb
+++ b/code/1_iii_tooling_2.rb
@@ -1,0 +1,1 @@
+system("CLS")

--- a/code/2_1_title_screen_1.rb
+++ b/code/2_1_title_screen_1.rb
@@ -1,0 +1,8 @@
+require "curses" # require the curses gem
+include Curses   # mixin curses
+
+# The next three methods are provided by including the Curses module.
+
+init_screen      # starts curses visual mode
+getch            # reads a single character from stdin
+close_screen     # closes the ncurses screen

--- a/code/2_1_title_screen_2.rb
+++ b/code/2_1_title_screen_2.rb
@@ -1,0 +1,26 @@
+class UI
+  include Curses
+
+  def initialize
+    noecho # do not print characters the user types
+    init_screen
+  end
+
+  def close
+    close_screen
+  end
+
+  def message(y, x, string)
+    setpos(y, x) # place the cursor at our position
+    addstr(string) # prints a string at cursor position
+  end
+
+  def choice_prompt(y, x, string, choices)
+    message(y, x, string + " ")
+
+    loop do
+      choice = getch
+      return choice if choices.include?(choice)
+    end
+  end
+end

--- a/code/2_1_title_screen_3.rb
+++ b/code/2_1_title_screen_3.rb
@@ -1,0 +1,22 @@
+class Game
+  def initialize
+    @ui = UI.new
+    at_exit { ui.close } # runs at program exit
+  end
+
+  def run
+    title_screen
+  end
+
+  private
+
+  attr_reader :ui
+
+  def title_screen
+    ui.message(0, 0, "Rhack, a NetHack clone")
+    ui.message(1, 7, "by a daring developer")
+    ui.choice_prompt(3, 0,
+                     "Shall I pick a character's race, role, gender and " +
+                     "alignment for you? [ynq]", "ynq")
+  end
+end

--- a/code/2_1_title_screen_4.rb
+++ b/code/2_1_title_screen_4.rb
@@ -1,0 +1,8 @@
+$LOAD_PATH.unshift "." # makes requiring files easier
+
+require "pp"
+require "curses"
+require "ui"
+require "game"
+
+Game.new.run

--- a/code/2_1_title_screen_5.rb
+++ b/code/2_1_title_screen_5.rb
@@ -1,0 +1,29 @@
+class Game
+  def initialize
+    @ui = UI.new
+    @options = { quit: false, randall: false } # variable for options
+
+    # See selected options at exit
+    at_exit do
+      ui.close
+      pp options
+    end
+  end
+
+  def run
+    title_screen
+  end
+
+  private
+
+  attr_reader :ui, :options # Add attr_reader for options
+
+  def title_screen
+    TitleScreen.new(ui, options).render
+    quit?
+  end
+
+  def quit?
+    exit if options[:quit]
+  end
+end

--- a/code/2_1_title_screen_6.rb
+++ b/code/2_1_title_screen_6.rb
@@ -1,0 +1,29 @@
+class TitleScreen
+  def initialize(ui, options)
+    @ui = ui
+    @options = options
+  end
+
+  def render
+    ui.message(0, 0, "Rhack, a NetHack clone")
+    ui.message(1, 7, "by a daring developer")
+    handle_choice prompt
+  end
+
+  private
+
+  attr_reader :ui, :options
+
+  def prompt
+    ui.choice_prompt(3, 0,
+                     "Shall I pick a character's race, role, gender and " +
+                     "alignment for you? [ynq]", "ynq")
+  end
+
+  def handle_choice(choice)
+    case choice
+    when "q" then options[:quit] = true
+    when "y" then options[:randall] = true
+    end
+  end
+end

--- a/code/2_1_title_screen_7.rb
+++ b/code/2_1_title_screen_7.rb
@@ -1,0 +1,1 @@
+require "title_screen"

--- a/code/2_2_messages_1.yaml
+++ b/code/2_2_messages_1.yaml
@@ -1,0 +1,5 @@
+---
+title:
+  name: Rhack, a NetHack clone
+  by: by a daring developer
+  pick_random: "Shall I pick a character's race, role, gender and alignment for you? [ynq]"

--- a/code/2_2_messages_2.rb
+++ b/code/2_2_messages_2.rb
@@ -1,0 +1,24 @@
+class DataLoader
+  def self.load_file(file)
+    new.load_file(file)
+  end
+
+  def load_file(file)
+    symbolize_keys YAML.load_file("data/#{file}.yaml")
+  end
+
+  private
+
+  def symbolize_keys(object)
+    case object
+    when Hash
+      object.each_with_object({}) do |(key, value), hash|
+        hash[key.to_sym] = symbolize_keys(value)
+      end
+    when Array
+      object.map { |element| symbolize_keys(element) }
+    else
+      object
+    end
+  end
+end

--- a/code/2_2_messages_3.rb
+++ b/code/2_2_messages_3.rb
@@ -1,0 +1,9 @@
+module Messages
+  def self.messages
+    @messages ||= DataLoader.load_file("messages")
+  end
+
+  def self.[](key)
+    messages[key]
+  end
+end

--- a/code/2_2_messages_4.rb
+++ b/code/2_2_messages_4.rb
@@ -1,0 +1,1 @@
+@messages = Messages[:title]

--- a/code/2_2_messages_5.rb
+++ b/code/2_2_messages_5.rb
@@ -1,0 +1,1 @@
+attr_reader :ui, :options, :messages

--- a/code/2_2_messages_6.rb
+++ b/code/2_2_messages_6.rb
@@ -1,0 +1,5 @@
+def render
+  ui.message(0, 0, messages[:name])
+  ui.message(1, 7, messages[:by])
+  handle_choice prompt
+end

--- a/code/2_2_messages_7.rb
+++ b/code/2_2_messages_7.rb
@@ -1,0 +1,3 @@
+def prompt
+  ui.choice_prompt(3, 0, messages[:pick_random], "ynq")
+end

--- a/code/2_3_role_call_1.yaml
+++ b/code/2_3_role_call_1.yaml
@@ -1,0 +1,27 @@
+---
+- name: Archeologist
+  hotkey: a
+- name: Barbarian
+  hotkey: b
+- name: Caveman
+  hotkey: c
+- name: Healer
+  hotkey: h
+- name: Knight
+  hotkey: k
+- name: Monk
+  hotkey: m
+- name: Priest
+  hotkey: p
+- name: Rogue
+  hotkey: r
+- name: Ranger
+  hotkey: R
+- name: Samurai
+  hotkey: s
+- name: Tourist
+  hotkey: t
+- name: Valkyrie
+  hotkey: v
+- name: Wizard
+  hotkey: w

--- a/code/2_3_role_call_10.rb
+++ b/code/2_3_role_call_10.rb
@@ -1,0 +1,8 @@
+def render_choices
+  items.each_with_index do |item, index|
+    ui.message(index + 2, right_offset, "#{item.hotkey} - #{item}")
+  end
+
+  ui.message(items.length + 2, right_offset, "* - Random")
+  ui.message(items.length + 3, right_offset, "q - Quit")
+end

--- a/code/2_3_role_call_11.rb
+++ b/code/2_3_role_call_11.rb
@@ -1,0 +1,11 @@
+def handle_choice(choice)
+  case choice
+  when "q" then options[:quit] = true
+  when "*" then options[key] = random_item
+  else options[key] = item_for_hotkey(choice)
+  end
+end
+
+def item_for_hotkey(hotkey)
+  items.detect { |item| item.hotkey == hotkey }
+end

--- a/code/2_3_role_call_12.rb
+++ b/code/2_3_role_call_12.rb
@@ -1,0 +1,7 @@
+def prompt
+  ui.choice_prompt(items.length + 4, right_offset, "(end)", hotkeys)
+end
+
+def hotkeys
+  items.map(&:hotkey).join + "*q"
+end

--- a/code/2_3_role_call_13.rb
+++ b/code/2_3_role_call_13.rb
@@ -1,0 +1,1 @@
+TRAITS = [Role].freeze

--- a/code/2_3_role_call_14.rb
+++ b/code/2_3_role_call_14.rb
@@ -1,0 +1,4 @@
+def run
+  title_screen
+  setup_character
+end

--- a/code/2_3_role_call_15.rb
+++ b/code/2_3_role_call_15.rb
@@ -1,0 +1,10 @@
+def setup_character
+  get_traits
+end
+
+def get_traits
+  TRAITS.each do |trait|
+    SelectionScreen.new(trait, ui, options).render
+    quit?
+  end
+end

--- a/code/2_3_role_call_16.rb
+++ b/code/2_3_role_call_16.rb
@@ -1,0 +1,2 @@
+require "role"
+require "selection_screen"

--- a/code/2_3_role_call_17.rb
+++ b/code/2_3_role_call_17.rb
@@ -1,0 +1,3 @@
+def clear
+  super # call curses's clear method
+end

--- a/code/2_3_role_call_18.rb
+++ b/code/2_3_role_call_18.rb
@@ -1,0 +1,7 @@
+def message(x, y, string)
+  x = x + cols if x < 0
+  y = y + lines if y < 0
+
+  setpos(y, x)
+  addstr(string)
+end

--- a/code/2_3_role_call_19.yaml
+++ b/code/2_3_role_call_19.yaml
@@ -1,0 +1,3 @@
+role:
+  choosing: Choosing Role
+  instructions: Pick a role for your character

--- a/code/2_3_role_call_2.rb
+++ b/code/2_3_role_call_2.rb
@@ -1,0 +1,23 @@
+class Role
+  def self.for_options(_)
+    all
+  end
+
+  def self.all
+    DataLoader.load_file("roles").map do |data|
+      new(data)
+    end
+  end
+
+  attr_reader :name, :hotkey
+
+  def initialize(data)
+    data.each do |key, value|
+      instance_variable_set("@#{key}", value)
+    end
+  end
+
+  def to_s
+    name
+  end
+end

--- a/code/2_3_role_call_3.rb
+++ b/code/2_3_role_call_3.rb
@@ -1,0 +1,2 @@
+class SelectionScreen
+end

--- a/code/2_3_role_call_4.rb
+++ b/code/2_3_role_call_4.rb
@@ -1,0 +1,13 @@
+def initialize(trait, ui, options)
+  @items = trait.for_options(options)
+
+  @ui = ui
+  @options = options
+
+  @key = trait.name.downcase.to_sym
+  @messages = Messages[key]
+end
+
+private
+
+attr_reader :items, :ui, :options, :key, :messages

--- a/code/2_3_role_call_5.rb
+++ b/code/2_3_role_call_5.rb
@@ -1,0 +1,1 @@
+SelectionScreen.new(Role, ui, options).render

--- a/code/2_3_role_call_6.rb
+++ b/code/2_3_role_call_6.rb
@@ -1,0 +1,7 @@
+def render
+  if random?
+    options[key] = random_item
+  else
+    render_screen
+  end
+end

--- a/code/2_3_role_call_7.rb
+++ b/code/2_3_role_call_7.rb
@@ -1,0 +1,7 @@
+def random?
+  options[:randall]
+end
+
+def random_item
+  items.sample
+end

--- a/code/2_3_role_call_8.rb
+++ b/code/2_3_role_call_8.rb
@@ -1,0 +1,14 @@
+def render_screen
+  ui.clear
+  ui.message(0, 0, messages[:choosing])
+  ui.message(0, right_offset, instructions)
+  render_choices
+  handle_choice prompt
+end
+
+# instructions has been pulled out into it's own method for a reason
+# you will see later
+
+def instructions
+  messages[:instructions]
+end

--- a/code/2_3_role_call_9.rb
+++ b/code/2_3_role_call_9.rb
@@ -1,0 +1,3 @@
+def right_offset
+  @right_offset ||= (instructions.length + 2) * -1
+end


### PR DESCRIPTION
I think we'd benefit from having a linting tool set up so that all of our sample code retains a consistent style. Following that train of thought a bit, I also thought it would be nice to be able to edit example code with correct syntax highlighting and all of the other niceties a well-configured text editor affords. So, we come now to…

## Source code injection

Editing each bit of sample code in its own file seemed like something that would fit the bill and the Pandoc-powered build tool I put together seemed like a good place to hook something up to handle this. After wiring everything up, I ended up with a `code` directory to hold all the sample code and was able to change stuff like this:

> ````ruby
> require "curses" # require the curses gem
> include Curses   # mixin curses
>
> # The next three methods are provided by including the Curses module.
>
> init_screen      # starts curses visual mode
> getch            # reads a single character from stdin
> close_screen     # closes the ncurses screen
> ```

To stuff like this:

> `!{code/2_1_title_screen_1.rb}`

I didn't swap out the code in all the files but did enough to hopefully provide a solid example of the general workflow.

Cool. Now sample code is super easy to lint, which brings us to…

## Linting

RuboCop is the de facto linter for maintaining Ruby code style, so I figured that would be the way to go for this project. In order to avoid bikeshedding (including of the personal variety), I simply copied down [thoughtbot's RuboCop config](https://github.com/thoughtbot/guides/blob/master/style/ruby/.rubocop.yml), updated it for the most current version of RuboCop, and fixed a small typo. You can now simply run `rubocop` in the root directory to have the files in `example_app` and `code` linted (I've not yet fixed any violations).