### PR TITLE
Add build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,11 @@
+# Building
+
+There is a build tool included with this project that will allow you to compile the contents of the `book` directory into an EPUB-formatted e-book. First, to ensure that you’ve got the necessary dependencies for the compilation process, change to the project directory and run:
+
+    $ bundle install
+
+Now, anytime you’d like to compile the book you can simply run the compile script:
+
+    $ exe/compile
+
+Doing so will write a file entitled `write-yourself-a-roguelike.epub` to the `release` directory, overwriting any existing file with the same name.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,15 @@ be writing a Roguelike.
   - [ ] Blessings and Curses
   - [ ] Pets
   - [ ] Zoos
+
+## Building
+
+There is a build tool included with this project that will allow you to compile the contents of the `book` directory into an EPUB-formatted e-book. First, to ensure that you’ve got the necessary dependencies for the compilation process, change to the project directory and run:
+
+    $ bundle install
+
+Now, anytime you’d like to compile the book you can simply run the compile script:
+
+    $ exe/compile
+
+Doing so will write a file entitled `write-yourself-a-roguelike.epub` to the `release` directory, overwriting any existing file with the same name.


### PR DESCRIPTION
This adds instructions on how to compile the EPUB to the README as well as a `BUILDING.md` file. Completes #36.