### PR TITLE
Added pandoc requirement to build instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /release/*
 !/release/.keep
+.DS_Store

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,6 +4,8 @@ There is a build tool included with this project that will allow you to compile 
 
     $ bundle install
 
+We then need to have [Pandoc](http://pandoc.org/installing.html) installed.
+
 Now, anytime you’d like to compile the book you can simply run the compile script:
 
     $ exe/compile

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ There is a build tool included with this project that will allow you to compile 
 
     $ bundle install
 
+We then need to have [Pandoc](http://pandoc.org/installing.html) installed.
+
 Now, anytime you’d like to compile the book you can simply run the compile script:
 
     $ exe/compile


### PR DESCRIPTION
I was getting the following error when I followed the build instructions:
```
open3.rb:199:in `spawn': No such file or directory - pandoc (Errno::ENOENT)
``` 
 I found that `pandoc-ruby` gem needs pandoc installed to work properly.